### PR TITLE
204 No Content revision

### DIFF
--- a/src/fetchUtils.js
+++ b/src/fetchUtils.js
@@ -23,7 +23,7 @@ handlers.decode = function (response) {
   if (response.status === 204) {
     return handlers.finish(response, null);
   }
-  
+
   const contentType = response.headers.get('content-type');
 
   if (contentType.includes('application/json')) {

--- a/src/fetchUtils.js
+++ b/src/fetchUtils.js
@@ -19,11 +19,14 @@ handlers.finish = function (response, data) {
  * @returns {Promise} promise
  */
 handlers.decode = function (response) {
+  // No content, ignore response and return success
+  if (response.status === 204) {
+    return handlers.finish(response, null);
+  }
+  
   const contentType = response.headers.get('content-type');
 
-  if (!contentType && response.status === 204) {
-    return handlers.finish(response, null);
-  } else if (contentType.includes('application/json')) {
+  if (contentType.includes('application/json')) {
     return response.json()
       .then(data => handlers.finish(response, data));
   }


### PR DESCRIPTION
Regardless of the headers, 204 should ignore the response data. We have APIs that erroneously return content types without any attached data at present which takes them down the wrong path, yielding a failure state.