### PR TITLE
Fix debouncing for same action name across instances

### DIFF
--- a/src/actionCreators.js
+++ b/src/actionCreators.js
@@ -191,10 +191,11 @@ export default function createActionCreators(apiName, apiDesc, apiConfig = {}) {
       return (dispatch, getState) => {
         const promiseKeeper = getPromiseKeeper(dispatch);
         const key = getResourceKey(resourceName, params);
+        const promiseKey = `${apiName}-${key}`;
         const resource = getState()[apiName] ? getState()[apiName][key] : null;
 
         // debounce request
-        if (promiseKeeper.has(key)) return promiseKeeper.get(key);
+        if (promiseKeeper.has(promiseKey)) return promiseKeeper.get(promiseKey);
 
         if (shouldThrottle(key, reqDesc, resource, force)) {
           return Promise.resolve(resource.hasError ?
@@ -210,7 +211,7 @@ export default function createActionCreators(apiName, apiDesc, apiConfig = {}) {
         const allOptions = getRequestOptions(apiOptions, reqOptions, options, getState);
         const promise = makeRequest(reqDesc.method, url, { ...allOptions }, apiConfig)
           .then(onResolved, onRejected);
-        promiseKeeper.set(key, promise);
+        promiseKeeper.set(promiseKey, promise);
         return promise;
       };
     };

--- a/tests/actionCreators.spec.js
+++ b/tests/actionCreators.spec.js
@@ -491,6 +491,17 @@ describe('ActionCreators', () => {
         const nextPromise = thunk(otherDispatch, getState);
         expect(firstPromise).not.toBe(nextPromise);
       });
+
+      it('does not debounce if dispatched from a different instance', () => {
+        const otherActions = createActionCreators('api2', mockApiDesc);
+
+        const thunk = actions.getFruit(mockParams);
+        const thunk2 = otherActions.getFruit(mockParams);
+
+        const firstPromise = thunk(dispatch, getState);
+        const nextPromise = thunk2(dispatch, getState);
+        expect(firstPromise).not.toBe(nextPromise);
+      });
     });
   });
 });


### PR DESCRIPTION
This fixes a regression due to a single promise keeper instance per store, instead of per Reduxful instance, introduced as a fix in #19. The issue being when two or more API descriptions have resources with the same name (used as a promise key). This PR includes the API name as part of the key.