### PR TITLE
Fix reducing similar action names

### DIFF
--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,5 +1,3 @@
-import { startsWith, endsWith } from './utils';
-
 export const handlers = {};
 
 handlers.onReset = function (state, action) {
@@ -59,11 +57,14 @@ handlers.onComplete = function (state, action) {
  * @private
  */
 export default function createReducer(apiName) {
+  const reApiAction = new RegExp(`${apiName}_(RESET|START|SUCCESS|FAIL)`);
   return function reducer(state = {}, action) {
-    if (startsWith(action.type, apiName)) {
-      if (endsWith(action.type, 'RESET')) return handlers.onReset(state, action);
-      if (endsWith(action.type, 'START')) return handlers.onStart(state, action);
-      if (endsWith(action.type, 'SUCCESS') || endsWith(action.type, 'FAIL')) return handlers.onComplete(state, action);
+    const match = reApiAction.exec(action.type);
+    if (match) {
+      const type = match[1];
+      if (type === 'RESET') return handlers.onReset(state, action);
+      if (type === 'START') return handlers.onStart(state, action);
+      if (type === 'SUCCESS' || type === 'FAIL') return handlers.onComplete(state, action);
     }
     return state;
   };

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -57,14 +57,14 @@ handlers.onComplete = function (state, action) {
  * @private
  */
 export default function createReducer(apiName) {
-  const reApiAction = new RegExp(`${apiName}_(RESET|START|SUCCESS|FAIL)`);
+  const reApiAction = new RegExp(`^${apiName}_(RESET|START|SUCCESS|FAIL)$`);
   return function reducer(state = {}, action) {
     const match = reApiAction.exec(action.type);
     if (match) {
       const type = match[1];
       if (type === 'RESET') return handlers.onReset(state, action);
       if (type === 'START') return handlers.onStart(state, action);
-      if (type === 'SUCCESS' || type === 'FAIL') return handlers.onComplete(state, action);
+      return handlers.onComplete(state, action);
     }
     return state;
   };

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,3 +1,5 @@
+import { escapeRegExp } from './utils';
+
 export const handlers = {};
 
 handlers.onReset = function (state, action) {
@@ -57,7 +59,8 @@ handlers.onComplete = function (state, action) {
  * @private
  */
 export default function createReducer(apiName) {
-  const reApiAction = new RegExp(`^${apiName}_(RESET|START|SUCCESS|FAIL)$`);
+  const safeName = escapeRegExp(apiName);
+  const reApiAction = new RegExp(`^${safeName}_(RESET|START|SUCCESS|FAIL)$`);
   return function reducer(state = {}, action) {
     const match = reApiAction.exec(action.type);
     if (match) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,27 +103,3 @@ export function getUrlTemplate(url, getState) {
   if (isFunction(url)) return url(getState);
   return url;
 }
-
-/**
- * Determines whether a string begins with the characters of a specified string
- *
- * @param {String} str - String to check
- * @param {String} search - String to search for at the start
- * @returns {Boolean} result
- * @private
- */
-export function startsWith(str, search) {
-  return str.indexOf(search) === 0;
-}
-
-/**
- * Determines whether a string ends with the characters of a specified string
- *
- * @param {String} str - String to check
- * @param {String} search - String to search for at the end
- * @returns {Boolean} result
- * @private
- */
-export function endsWith(str, search) {
-  return str.lastIndexOf(search) === (str.length - search.length);
-}

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,3 +103,14 @@ export function getUrlTemplate(url, getState) {
   if (isFunction(url)) return url(getState);
   return url;
 }
+
+/**
+ * Escape special characters for RegExp
+ *
+ * @see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+ * @param {string} string - Intended for expression
+ * @returns {string} escaped
+ */
+export function escapeRegExp(string) {
+  return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}

--- a/tests/reducers.spec.js
+++ b/tests/reducers.spec.js
@@ -128,6 +128,13 @@ describe('Reducers', () => {
       expect(handlers.onComplete).not.toHaveBeenCalled();
       expect(handlers.onReset).toHaveBeenCalled();
     });
+
+    it('does not handler for similarly named apis', () => {
+      const inState = { bogus: 'bogus' };
+      reducer(inState, { type: 'mockApi_2_START' });
+      reducer(inState, { type: 'mockApi2_START' });
+      expect(handlers.onStart).not.toHaveBeenCalled();
+    });
   });
   describe('handleStart', () => {
 

--- a/tests/reducers.spec.js
+++ b/tests/reducers.spec.js
@@ -129,6 +129,17 @@ describe('Reducers', () => {
       expect(handlers.onReset).toHaveBeenCalled();
     });
 
+    it('handles special characters in api names', () => {
+      const inState = { bogus: 'bogus' };
+      reducer = createReducer('a*b+c');
+      reducer(inState, { type: 'a*b+c_START' });
+      expect(handlers.onStart).toHaveBeenCalled();
+
+      reducer = createReducer('api(v2)');
+      reducer(inState, { type: 'api(v2)_SUCCESS' });
+      expect(handlers.onComplete).toHaveBeenCalled();
+    });
+
     it('does not handle for similarly named apis', () => {
       const inState = { bogus: 'bogus' };
       reducer(inState, { type: '2mockApi_START' });

--- a/tests/reducers.spec.js
+++ b/tests/reducers.spec.js
@@ -129,7 +129,7 @@ describe('Reducers', () => {
       expect(handlers.onReset).toHaveBeenCalled();
     });
 
-    it('does not handler for similarly named apis', () => {
+    it('does not handle for similarly named apis', () => {
       const inState = { bogus: 'bogus' };
       reducer(inState, { type: '2mockApi_START' });
       reducer(inState, { type: 'mockApi_2_START' });
@@ -138,7 +138,7 @@ describe('Reducers', () => {
       expect(handlers.onStart).not.toHaveBeenCalled();
     });
 
-    it('does not handler for unknown actions', () => {
+    it('does not handle for unknown actions', () => {
       const inState = { bogus: 'bogus' };
       reducer(inState, { type: 'mockApi_2START' });
       reducer(inState, { type: 'mockApi_START2' });

--- a/tests/reducers.spec.js
+++ b/tests/reducers.spec.js
@@ -131,8 +131,19 @@ describe('Reducers', () => {
 
     it('does not handler for similarly named apis', () => {
       const inState = { bogus: 'bogus' };
+      reducer(inState, { type: '2mockApi_START' });
       reducer(inState, { type: 'mockApi_2_START' });
       reducer(inState, { type: 'mockApi2_START' });
+      reducer(inState, { type: 'MOCKAPI_START' });
+      expect(handlers.onStart).not.toHaveBeenCalled();
+    });
+
+    it('does not handler for unknown actions', () => {
+      const inState = { bogus: 'bogus' };
+      reducer(inState, { type: 'mockApi_2START' });
+      reducer(inState, { type: 'mockApi_START2' });
+      reducer(inState, { type: 'mockApi__START' });
+      reducer(inState, { type: 'mockApi_start' });
       expect(handlers.onStart).not.toHaveBeenCalled();
     });
   });

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -6,7 +6,8 @@ import {
   isFunction,
   getUrlTemplate,
   parseReqDesc,
-  parseApiDesc
+  parseApiDesc,
+  escapeRegExp
 } from '../src/utils';
 import * as utils from '../src/utils';
 
@@ -214,6 +215,13 @@ describe('Utils', () => {
       expect(results).toHaveProperty('test3', expect.objectContaining({
         method: 'PATCH'
       }));
+    });
+  });
+
+  describe('escapeRegExp', () => {
+
+    it('escaped special characters', () => {
+      expect(escapeRegExp('a*b+c')).toEqual('a\\*b\\+c');
     });
   });
 });

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -6,9 +6,7 @@ import {
   isFunction,
   getUrlTemplate,
   parseReqDesc,
-  parseApiDesc,
-  startsWith,
-  endsWith
+  parseApiDesc
 } from '../src/utils';
 import * as utils from '../src/utils';
 
@@ -218,47 +216,4 @@ describe('Utils', () => {
       }));
     });
   });
-
-  describe('startsWith', () => {
-
-    it('returns true if search string is at start', () => {
-      expect(startsWith('example', 'ex')).toBe(true);
-    });
-
-    it('returns false if search string is not at start', () => {
-      expect(startsWith('example', 'no')).toBe(false);
-    });
-
-    it('returns false if search string is not at start, even if present', () => {
-      expect(startsWith('example', 'amp')).toBe(false);
-    });
-  });
-
-  describe('endsWith', () => {
-
-    it('returns true is search string is at end', () => {
-      expect(endsWith('example', 'le')).toBe(true);
-    });
-
-    it('handles a string with multiple occurences', () => {
-      expect(endsWith('siryessir', 'sir')).toBe(true);
-    });
-
-    it('handles an empty search string', () => {
-      expect(endsWith('example', '')).toBe(true);
-    });
-
-    it('returns false if search string is not at end', () => {
-      expect(endsWith('example', 'no')).toBe(false);
-    });
-
-    it('returns false if search string is not at end, even if present', () => {
-      expect(endsWith('example', 'amp')).toBe(false);
-    });
-
-    it('handles an empty string', () => {
-      expect(endsWith('', 'amp')).toBe(false);
-    });
-  });
-
 });


### PR DESCRIPTION
Fix edge case where actions for similar API names we being reduced improperly (i.e. `api_START` and `api2_START`).