### PR TITLE
Remove erroneous declaration

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -103,6 +103,4 @@ declare module 'reduxful' {
     apiDesc: ApiDescription,
     config?: ApiConfig
   ): Reduxful;
-
-  export default Reduxful;
 }


### PR DESCRIPTION
This line breaks typescript builds that use `reduxful`:

```

./lib/dataApi.js:1:1
Type error: Declaration emit for this file requires using private name 'Reduxful' from module '"reduxful"'. An explicit type annotation may unblock declaration emit.

> 1 | const fetch = require('@private-library/fetch');
    | ^
  2 | const { setupApi, makeFetchAdapter } = require('reduxful');
```

This PR represents the remove of the problematic "`explicit type annotation may unblock declaration emit.`"

Testing strategy: I made this change locally in `node_modules` and fixed my build