### PR TITLE
add options to the transformFn so the transformFn can have access to the body or other options if needed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
-    extends: [ 'godaddy', 'plugin:jest/recommended' ],
-    rules  : {
-        "max-params": [ 2, 5 ]
-    }
+  extends: [ 'godaddy', 'plugin:jest/recommended' ],
+  rules  : {
+    "max-params": [ 2, 5 ]
+  }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-  extends: ['godaddy', 'plugin:jest/recommended']
+    extends: [ 'godaddy', 'plugin:jest/recommended' ],
+    rules  : {
+        "max-params": [ 2, 5 ]
+    }
 };

--- a/tests/actionCreators.spec.js
+++ b/tests/actionCreators.spec.js
@@ -11,6 +11,7 @@ import { mockApiName, mockApiDesc } from './fixtures/mockApi';
 
 const mockPayload = { some: 'data' };
 const mockParams = { id: 1234 };
+const mockOptions = { };
 const mockKey = 'getFruit__id:1234';
 
 const fsaProperties = ['type', 'payload', 'error', 'meta'];
@@ -243,7 +244,7 @@ describe('ActionCreators', () => {
         success: jest.fn(),
         fail: jest.fn()
       };
-      [onStart, onResolved, onRejected] = createDispatchers(dispatch, mockReqDesc, subActions, mockParams);
+      [onStart, onResolved, onRejected] = createDispatchers(dispatch, mockReqDesc, subActions, mockParams, mockOptions);
     });
 
     describe('onStart', () => {
@@ -262,7 +263,7 @@ describe('ActionCreators', () => {
       it('executes dataTransform', () => {
         const mockData = { bogus: 'BOGUS' };
         onResolved(mockData);
-        expect(mockDataTransform).toHaveBeenCalledWith(mockData, { params: mockParams });
+        expect(mockDataTransform).toHaveBeenCalledWith(mockData, { params: mockParams, options:mockOptions });
       });
     });
 
@@ -275,7 +276,7 @@ describe('ActionCreators', () => {
       it('executes errorTransform', () => {
         const mockError = { something: 'terrible' };
         onRejected(mockError);
-        expect(mockErrorTransform).toHaveBeenCalledWith(mockError, { params: mockParams });
+        expect(mockErrorTransform).toHaveBeenCalledWith(mockError, { params: mockParams, options:mockOptions });
       });
     });
   });

--- a/tests/actionCreators.spec.js
+++ b/tests/actionCreators.spec.js
@@ -263,7 +263,7 @@ describe('ActionCreators', () => {
       it('executes dataTransform', () => {
         const mockData = { bogus: 'BOGUS' };
         onResolved(mockData);
-        expect(mockDataTransform).toHaveBeenCalledWith(mockData, { params: mockParams, options:mockOptions });
+        expect(mockDataTransform).toHaveBeenCalledWith(mockData, { params: mockParams, options: mockOptions });
       });
     });
 
@@ -276,7 +276,7 @@ describe('ActionCreators', () => {
       it('executes errorTransform', () => {
         const mockError = { something: 'terrible' };
         onRejected(mockError);
-        expect(mockErrorTransform).toHaveBeenCalledWith(mockError, { params: mockParams, options:mockOptions });
+        expect(mockErrorTransform).toHaveBeenCalledWith(mockError, { params: mockParams, options: mockOptions });
       });
     });
   });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -34,7 +34,7 @@ declare module 'reduxful' {
   ): string;
 
   // reduxful
-  export type TransformFn = (data: any, context?: { params?: Object }) => any;
+  export type TransformFn = (data: any, context?: { params?: Object, options?: Object }) => any;
 
   export type UrlTemplateFn = (getState: () => any) => string;
 


### PR DESCRIPTION
There is a need for us to inject into the response values that where in the original request body. We are wanting to inject the additional values before hitting the success reducer.