### PR TITLE
Json decode catch

### DIFF
--- a/src/fetchUtils.js
+++ b/src/fetchUtils.js
@@ -25,11 +25,19 @@ handlers.decode = function (response) {
   }
 
   const contentType = response.headers.get('content-type');
-
   if (contentType.includes('application/json')) {
     return response.json()
-      .then(data => handlers.finish(response, data));
+      .then(data => handlers.finish(response, data))
+      .catch(e =>
+        response.text()
+          .then(data => {
+            if (!data) {
+              return handlers.finish(response, null);
+            }
+            throw e;
+          }));
   }
+
   try {
     return response.text()
       .then(data => handlers.finish(response, data));
@@ -47,12 +55,12 @@ handlers.decode = function (response) {
  */
 export function makeFetchAdapter(fetcher, defaultOptions = {}) {
   /**
-   * The RequestAdapter using Fetch
-   *
-   * @param {RequestAdapterOptions} options - Options from the request call
-   * @returns {Promise} promise
-   * @private
-   */
+     * The RequestAdapter using Fetch
+     *
+     * @param {RequestAdapterOptions} options - Options from the request call
+     * @returns {Promise} promise
+     * @private
+     */
   function fetchAdapter(options) {
     const { url, withCredentials, ...rest } = options;
     const outOpts = { ...defaultOptions, ...rest };

--- a/src/fetchUtils.js
+++ b/src/fetchUtils.js
@@ -25,6 +25,7 @@ handlers.decode = function (response) {
   }
 
   const contentType = response.headers.get('content-type');
+
   if (contentType.includes('application/json')) {
     return response.json()
       .then(data => handlers.finish(response, data))

--- a/src/fetchUtils.js
+++ b/src/fetchUtils.js
@@ -55,12 +55,12 @@ handlers.decode = function (response) {
  */
 export function makeFetchAdapter(fetcher, defaultOptions = {}) {
   /**
-     * The RequestAdapter using Fetch
-     *
-     * @param {RequestAdapterOptions} options - Options from the request call
-     * @returns {Promise} promise
-     * @private
-     */
+   * The RequestAdapter using Fetch
+   *
+   * @param {RequestAdapterOptions} options - Options from the request call
+   * @returns {Promise} promise
+   * @private
+   */
   function fetchAdapter(options) {
     const { url, withCredentials, ...rest } = options;
     const outOpts = { ...defaultOptions, ...rest };

--- a/tests/fetchUtils.spec.js
+++ b/tests/fetchUtils.spec.js
@@ -147,6 +147,35 @@ describe('fetchUtils', () => {
         { message: 'Content-type some/type not supported' }
       ));
     });
+
+    it('decodes and resolves JSON content with null response', async () => {
+      mockResponse.headers.set('content-type', 'application/json');
+      mockResponse.json.mockResolvedValue(Promise.reject(new Error()));
+      mockResponse.text.mockResolvedValue(Promise.resolve(null));
+
+      const data = await handlers.decode(mockResponse);
+      expect(data).toBe(null);
+    });
+
+    it('decodes and resolves JSON content with empty string response', async () => {
+      mockResponse.headers.set('content-type', 'application/json');
+      mockResponse.json.mockResolvedValue(Promise.reject(new Error()));
+      mockResponse.text.mockResolvedValue(Promise.resolve(''));
+
+      const data = await handlers.decode(mockResponse);
+      expect(data).toBe(null);
+    });
+
+    it('decodes and resolves JSON throws invalid error', async () => {
+      mockResponse.headers.set('content-type', 'application/json');
+      mockResponse.json.mockResolvedValue(Promise.reject(new Error('bad json format')));
+      mockResponse.text.mockResolvedValue(Promise.resolve('NOT JSON'));
+
+      const result = handlers.decode(mockResponse);
+      await expect(result).rejects.toEqual(expect.objectContaining(
+        { message: 'bad json format' }
+      ));
+    });
   });
 
   describe('Finish Handler', () => {


### PR DESCRIPTION
Certain success codes may or may not have a response but the endpoint requires a content-type of `json`. For example code 202 is for a pending action, but the api might not have anything to respond with. 

Currently if no response is given when the code tries to jsonDecode the response an error is thrown when the request was a success. This change will update the JSON decoding to catch errors and watch for null or empty strings. When an empty string or null response is seen the code will proceed with a success, otherwise it will throw the original error.
