### PR TITLE
Avoid response.clone

### DIFF
--- a/src/fetchUtils.js
+++ b/src/fetchUtils.js
@@ -27,18 +27,15 @@ handlers.decode = function (response) {
   const contentType = response.headers.get('content-type');
 
   if (contentType.includes('application/json')) {
-    return response.clone().json()
+    return response.json()
       .then(data => handlers.finish(response, data))
-      .catch(e =>
-        response.text()
-          .then(data => {
-            if (!data) {
-              return handlers.finish(response, null);
-            }
-            throw e;
-          }).catch(() => {
-            throw e;
-          }));
+      .catch(e => {
+        // No content, ignore response and return success
+        if (response.status === 202) {
+          return handlers.finish(response, null);
+        }
+        throw e;
+      });
   }
 
   try {

--- a/tests/fetchUtils.spec.js
+++ b/tests/fetchUtils.spec.js
@@ -150,22 +150,20 @@ describe('fetchUtils', () => {
       ));
     });
 
-    it('decodes and resolves JSON content with null response', async () => {
+    it('decodes and resolves no content on a 202 response', async () => {
       mockResponse.headers.set('content-type', 'application/json');
+      mockResponse.status = 202;
       mockResponse.json.mockResolvedValue(Promise.reject(new Error()));
-      mockResponse.text.mockResolvedValue(Promise.resolve(null));
 
       const data = await handlers.decode(mockResponse);
       expect(data).toBe(null);
     });
 
-    it('decodes and resolves JSON content with empty string response', async () => {
+    it('decodes and resolves JSON content on a 202 response', async () => {
       mockResponse.headers.set('content-type', 'application/json');
-      mockResponse.json.mockResolvedValue(Promise.reject(new Error()));
-      mockResponse.text.mockResolvedValue(Promise.resolve(''));
-
+      mockResponse.status = 202;
       const data = await handlers.decode(mockResponse);
-      expect(data).toBe(null);
+      expect(data).toBe(mockJsonData);
     });
 
     it('decodes and resolves JSON throws invalid error', async () => {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

With `response.clone()`, large responses were severely hanging and causing request timeouts for server-side rendered pages. This PR drops the `response.clone()` but still handles cases where a service returns a 202 with `application/json` content type but no actual content. This was the initial driver for changes in #61 and #62.

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## Changelog

- Remove `response.clone()`

<!--
Help reviewers and the release process by writing your own changelog entry.
-->
