### PR TITLE
fix: typings for `ActionCreatorThunkFn`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -35,7 +35,10 @@ declare module 'reduxful' {
   ): string;
 
   // reduxful
-  export type TransformFn = (data: any, context?: { params?: Object, options?: Object }) => any;
+  export type TransformFn = (
+    data: any,
+    context?: { params?: Object; options?: Object }
+  ) => any;
 
   export type UrlTemplateFn = (getState: () => any) => string;
 
@@ -68,10 +71,10 @@ declare module 'reduxful' {
     error?: boolean;
   }
 
-  export type ActionCreatorThunkFn = (
-    dispatch: () => any,
-    getState: () => any
-  ) => Promise<Action>;
+  export type ActionCreatorThunkFn<State = any> = (
+    dispatch: (action: ActionCreatorThunkFn) => any,
+    getState: () => State
+  ) => Promise<Action | void>;
 
   export type ActionCreatorFn<Options = Object> = (
     params: { [paramName: string]: any },
@@ -96,7 +99,11 @@ declare module 'reduxful' {
     public reducers: { [key: string]: ReducerFn };
     public reducerMap: { [key: string]: ReducerFn };
     public selectors: { [key: string]: SelectorFn };
-    constructor(apiName: string, apiDesc: ApiDescription, apiConfig?: ApiConfig);
+    constructor(
+      apiName: string,
+      apiDesc: ApiDescription,
+      apiConfig?: ApiConfig
+    );
   }
 
   export function setupApi(


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes.
Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

<!--
Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

### Problem

There's a current issue with typing for following scenario
```typescript

const { myThunkedAction }  = myReduxfulApi.actions;
const dispatch = useDispatch();

const myThunkedActionCreator = async (_dispatch, getState) => {
    const state = getState();
    // ...
    _dispatch(myThunkedAction)
}

dispatch(myThunkedActionCreator)
```


Here, we'll get following eslint error for `_dispatch` and `getState`

> Parameter `_dispatch` implicitly has `any` type.

Also, `state` here has implicit `any` type, which is not helpful

### Solution/Benefits with Proposed changes
 
 Consider this code with following changes
 
 ```typescript

import { type ActionCreatorThunkFn } from 'reduxful';
 
 type RootState = {
  foo: string;
  bar: number;
}

const { myThunkedAction }  = myReduxfulApi.actions;
const dispatch = useDispatch();

const myThunkedActionCreator: ActionCreatorThunkFn<RootState> = async (_dispatch, getState) => {
    const state = getState();
    // ...
    // state.foo and state.bar are known to typescript
    _dispatch(myThunkedAction)
}

dispatch(myThunkedActionCreator)
 ```

With these changes, there will be no `any` issues with typescript and state will be determined


## Changelog

<!--
Help reviewers and the release process by writing your own changelog entry.
-->
1. Update to `ActionCreatorThunkFn` typings
